### PR TITLE
chore: run action on Node 24

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/sync-teams.yml
+++ b/.github/workflows/sync-teams.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/sync-teams.js'
 branding:
   icon: 'users'

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript-eslint": "^8.65.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "keywords": [
     "github",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ['scripts/sync-teams.ts'],
   format: ['cjs'],
   outDir: 'dist',
-  target: 'node20',
+  target: 'node24',
   clean: true,
   dts: false,
   minify: false,


### PR DESCRIPTION
## Summary
- Clears the runner warning: *Node.js 20 is deprecated… actionsforge/actions-gh-teams-sync@v1*
- Set `runs.using: node24`, CI/`setup-node` to 24, and tsup target to `node24`

## Test plan
- [x] `npm test` / `npm run build` locally
- [ ] CI green
- [ ] After merge + release tag move, re-run platformfuzz/gh-team-sync and confirm the Node 20 annotation is gone