### PR TITLE
fix: bump js-yaml and nanoid for npm audit

### DIFF
--- a/dist/sync-teams.js
+++ b/dist/sync-teams.js
@@ -25014,7 +25014,7 @@ function requireOmap() {
   const _toString = Object.prototype.toString;
   function resolveYamlOmap(data) {
     if (data === null) return true;
-    const objectKeys = [];
+    const objectKeys = {};
     const object = data;
     for (let index = 0, length = object.length; index < length; index += 1) {
       const pair = object[index];
@@ -25028,8 +25028,8 @@ function requireOmap() {
         }
       }
       if (!pairHasKey) return false;
-      if (objectKeys.indexOf(pairKey) === -1) objectKeys.push(pairKey);
-      else return false;
+      if (_hasOwnProperty.call(objectKeys, pairKey)) return false;
+      Object.defineProperty(objectKeys, pairKey, { value: true });
     }
     return true;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^3.0.1",
         "@actions/github": "^9.1.1",
         "@octokit/rest": "^22.0.1",
-        "js-yaml": "^4.3.0"
+        "js-yaml": "^4.3.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -3297,9 +3297,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -3769,9 +3769,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@actions/core": "^3.0.1",
     "@actions/github": "^9.1.1",
     "@octokit/rest": "^22.0.1",
-    "js-yaml": "^4.3.0"
+    "js-yaml": "^4.3.1"
   },
   "devDependencies": {
     "@types/istanbul-lib-coverage": "^2.0.6",
@@ -53,8 +53,9 @@
   "license": "MIT",
   "overrides": {
     "brace-expansion": "5.0.9",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "postcss": "8.5.23",
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "nanoid": "^3.3.17"
   }
 }


### PR DESCRIPTION
## Summary
- Scheduled Validate failed on `npm audit --audit-level=high` ([run 31230553896](https://github.com/actionsforge/actions-gh-teams-sync/actions/runs/31230553896/job/93033401116))
- `js-yaml` → `^4.3.1` (GHSA-5p4m-2wfm-xmqj)
- `nanoid` override → `^3.3.17` via postcss (GHSA-2v37-7h3g-55p8)
- Rebuilt committed `dist/sync-teams.js`

Closes #67

## Test plan
- [x] `npm audit --audit-level=high` clean (0 vulnerabilities)
- [x] `npm test`, `npm run lint`, `npm run build` pass
- [ ] CI Validate passes